### PR TITLE
Update readme to explain from where 'docs' should be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ import 'storybook-addon-react-flow-docgen/dist/register';
 Then add a decorator to your stories:
 
 ```js
+import docs from 'storybook-addon-react-flow-docgen/dist';
+
 storiesOf('ButtonSimple')
   .addDecorator(docs())
   .add(


### PR DESCRIPTION
Hello Adam.

Thank you for this addon!
I'm currently looking for a doc generation tool for my project at work.
I'm testing `react-docgen`. As it does not support flow types, I was looking for a tool that allow to parse them and I found yours.

It works well. 

However I had to read the source code to understand which is the import path for `docs`. Having it in the readme will save time for others.